### PR TITLE
v1.2.0: Improved query parameter support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,3 +3,4 @@ v1.0.1, 2018-10-05 -- Support empty YAML files
 v1.0.2, 2018-10-08 -- Handle extra arguments from views in Django without erroring
 v1.1.0, 2018-10-09 -- Rename django->django_helpers flask->flask_helpers modules to avoid namespace clashes
 v1.1.1, 2019-03-30 -- Security: Always specify loaders when using yaml.load()
+v1.2.0, 2021-05-27 -- Improve query parameter support

--- a/canonicalwebteam/yaml_responses/flask_helpers.py
+++ b/canonicalwebteam/yaml_responses/flask_helpers.py
@@ -1,6 +1,7 @@
 # Standard library
 import os
 import re
+from urllib.parse import urlparse
 
 # Packages
 import flask
@@ -50,10 +51,20 @@ class YamlRegexMap:
 
                 target_url = target.format(**parts)
 
-                if flask.request.query_string:
-                    target_url += "?" + flask.request.query_string.decode(
-                        "utf-8"
-                    )
+                # Add request query parameters
+                parsed_target_url = urlparse(target_url)
+                target_query = parsed_target_url.query
+                request_query = flask.request.query_string.decode()
+
+                if request_query:
+                    if target_query:
+                        target_url = parsed_target_url._replace(
+                            query=f"{target_query}&{request_query}"
+                        ).geturl()
+                    else:
+                        target_url = parsed_target_url._replace(
+                            query=request_query
+                        ).geturl()
 
                 return target_url
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.yaml-responses",
-    version="1.1.1",
+    version="1.2.0",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/yaml-responses",
     packages=["canonicalwebteam.yaml_responses"],

--- a/tests/fixtures/redirects.yaml
+++ b/tests/fixtures/redirects.yaml
@@ -1,2 +1,3 @@
 hello: /world
+hello-query: /world?query=query
 example-(?P<name>.*): http://example.com/{name}

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -75,11 +75,17 @@ class TestFlaskRedirects(unittest.TestCase):
         """
 
         redirect = self.app_redirects.get("/hello?name=world")
+        redirect_query = self.app_redirects.get("/hello-query?name=world")
 
         self.assertEqual(redirect.status_code, 302)
+        self.assertEqual(redirect_query.status_code, 302)
         self.assertEqual(
             redirect.headers.get("Location"),
             "http://localhost/world?name=world",
+        )
+        self.assertEqual(
+            redirect_query.headers.get("Location"),
+            "http://localhost/world?query=query&name=world",
         )
 
     def test_permanent_redirect(self):


### PR DESCRIPTION
Now, query parameters from the request will be properly added to
parameters on the target.

E.g.:

request: /hello
target: /world?query=query

If you request `/hello?fish=chips`, you used to get
`/world?query=query?fish=chips` which is obviously broken.
Now you get `/world?query=query;fish=chips`.

We don't do any intelligent merging of parameters with the same name
because we can't know if that's what the target would expect.

Fixes https://github.com/canonical-web-and-design/canonicalwebteam.yaml-responses/issues/8

QA
--

Maybe the test passing is sufficient?